### PR TITLE
aa/feature/logout-dialog

### DIFF
--- a/common/src/commonMain/kotlin/chat/sphinx/common/state/ConfirmationTypeWindowState.kt
+++ b/common/src/commonMain/kotlin/chat/sphinx/common/state/ConfirmationTypeWindowState.kt
@@ -19,4 +19,7 @@ sealed class ConfirmationType {
     data class PodcastShare(
         val fromBeginningLink: String,
         val fromCurrentTimeLink: String
-    ) : ConfirmationType()}
+    ) : ConfirmationType()
+    object RemoveAccount : ConfirmationType()
+}
+

--- a/common/src/commonMain/kotlin/chat/sphinx/common/viewmodel/DashboardViewModel.kt
+++ b/common/src/commonMain/kotlin/chat/sphinx/common/viewmodel/DashboardViewModel.kt
@@ -141,7 +141,6 @@ class DashboardViewModel(): WindowFocusListener {
         _floatingPlayerStateFlow.value = null
     }
 
-    // Add to DashboardViewModel class
     private val _webAppWindowStateFlow: MutableStateFlow<Boolean> by lazy {
         MutableStateFlow(false)
     }
@@ -149,6 +148,9 @@ class DashboardViewModel(): WindowFocusListener {
     private val _webViewStateFlow: MutableStateFlow<String?> by lazy {
         MutableStateFlow(null)
     }
+
+    private val _removeAccountFlow = MutableStateFlow(false)
+    val removeAccountFlow: StateFlow<Boolean> = _removeAccountFlow.asStateFlow()
 
     val webAppWindowStateFlow: StateFlow<Boolean>
         get() = _webAppWindowStateFlow.asStateFlow()
@@ -763,6 +765,12 @@ class DashboardViewModel(): WindowFocusListener {
             queries.transaction {
                 deleteAll(queries)
             }
+        }
+    }
+
+    fun removeAccountConfirmed() {
+        viewModelScope.launch(dispatchers.main) {
+            _removeAccountFlow.value = true
         }
     }
 

--- a/common/src/desktopMain/kotlin/chat/sphinx/common/components/ConfirmationUI.kt
+++ b/common/src/desktopMain/kotlin/chat/sphinx/common/components/ConfirmationUI.kt
@@ -51,10 +51,11 @@ fun ConfirmationUI(
                 is ConfirmationType.TribeDeleteMember -> "Confirm Delete Member"
                 is ConfirmationType.ContactDelete -> "Confirm Delete Contact"
                 is ConfirmationType.PodcastShare -> "Share Episode"
+                is ConfirmationType.RemoveAccount -> "Logout"
             },
             state = WindowState(
                 position = WindowPosition.Aligned(Alignment.Center),
-                size = getPreferredWindowSize(300, 190)
+                size = getPreferredWindowSize(360, 220)
             )
         ) {
             Column(
@@ -81,11 +82,14 @@ fun ConfirmationUI(
                         is ConfirmationType.TribeDeleteMember -> "Are you sure you want to remove ${confirmationType.alias?.value}?"
                         is ConfirmationType.ContactDelete -> "Are you sure you want to delete this contact?"
                         is ConfirmationType.PodcastShare -> "Share from beginning or current time?"
+                        is ConfirmationType.RemoveAccount -> "Are you sure you want to logout? All data and preferences will be deleted."
                     },
                     color = MaterialTheme.colorScheme.tertiary,
+
                     fontFamily = Roboto,
                     fontWeight = FontWeight.Light,
-                    fontSize = 13.sp
+                    fontSize = 13.sp,
+                    textAlign = TextAlign.Center
                 )
 
                 Spacer(Modifier.height(16.dp))
@@ -98,7 +102,8 @@ fun ConfirmationUI(
                     when (confirmationType) {
                         is ConfirmationType.PayInvoice,
                         is ConfirmationType.TribeDeleteMember,
-                        is ConfirmationType.ContactDelete -> {
+                        is ConfirmationType.ContactDelete,
+                        is ConfirmationType.RemoveAccount -> {
                             Button(
                                 onClick = {
                                     isOpen = false
@@ -136,6 +141,10 @@ fun ConfirmationUI(
 
                                         is ConfirmationType.ContactDelete -> {
                                             dashboardViewModel.deleteSelectedContact()
+                                        }
+
+                                        is ConfirmationType.RemoveAccount -> {
+                                            dashboardViewModel.removeAccountConfirmed()
                                         }
 
                                         else -> {}

--- a/desktop/src/jvmMain/kotlin/Main.kt
+++ b/desktop/src/jvmMain/kotlin/Main.kt
@@ -82,6 +82,16 @@ fun main() = application {
             val dashboardViewModel = remember { DashboardViewModel() }
             WebViewInitializing(dashboardViewModel)
 
+            val removeAccount by dashboardViewModel.removeAccountFlow.collectAsState()
+
+            LaunchedEffect(removeAccount) {
+                if (removeAccount) {
+                    sphinxStore.removeAccount()
+                    dashboardViewModel.clearDatabase()
+                    exitApplication()
+                }
+            }
+
             Window(
                 onCloseRequest = {
                     dashboardViewModel.cleanup()
@@ -106,9 +116,10 @@ fun main() = application {
                         when (DashboardScreenState.screenState()) {
                             DashboardScreenType.Unlocked -> {
                                 Item("Remove Account from this machine", onClick = {
-                                    sphinxStore.removeAccount()
-                                    dashboardViewModel.clearDatabase()
-                                    exitApplication()
+                                    dashboardViewModel.toggleConfirmationWindow(
+                                        true,
+                                        ConfirmationType.RemoveAccount
+                                    )
                                 })
                             }
                             else -> {}


### PR DESCRIPTION
- Add RemoveAccount confirmation Type
- Implement remove account text and dialog
- Fix UI dialog box so it does not cut text in the middle.
- Workaround to access to sphinxStore after dialog is confirmed and delete user
- Implement removeAccountFlow on DashboardViewModel to be collected by Main
- Trigger a confirmation dialog instead removing the account immediately
- Remove account from main based on removeAccountFlow state